### PR TITLE
Hi, here is a fix for an edge-case, that wasn't properly handled.

### DIFF
--- a/security/SFHFKeychainUtils.m
+++ b/security/SFHFKeychainUtils.m
@@ -385,10 +385,12 @@ static NSString *SFHFKeychainUtilsErrorDomain = @"SFHFKeychainUtilsErrorDomain";
 		status = SecItemAdd((CFDictionaryRef) query, NULL);
 	}
 	
-	if (error != nil && status != noErr) 
+	if (status != noErr) 
   {
 		// Something went wrong with adding the new item. Return the Keychain error code.
-		*error = [NSError errorWithDomain: SFHFKeychainUtilsErrorDomain code: status userInfo: nil];
+		if (error != nil) {
+			*error = [NSError errorWithDomain: SFHFKeychainUtilsErrorDomain code: status userInfo: nil];
+		}
     
     return NO;
 	}
@@ -419,9 +421,11 @@ static NSString *SFHFKeychainUtilsErrorDomain = @"SFHFKeychainUtilsErrorDomain";
 	
 	OSStatus status = SecItemDelete((CFDictionaryRef) query);
 	
-	if (error != nil && status != noErr) 
+	if (status != noErr) 
   {
-		*error = [NSError errorWithDomain: SFHFKeychainUtilsErrorDomain code: status userInfo: nil];		
+	  if (error != nil) {
+		  *error = [NSError errorWithDomain: SFHFKeychainUtilsErrorDomain code: status userInfo: nil];
+	  }
     
     return NO;
 	}


### PR DESCRIPTION
Fixed a problem where deleteItem... and storeUsername:... would return YES, regardless of success, when nil is passed as the error-pointer.
