### PR TITLE
Do not #import UIKit if it is not required

### DIFF
--- a/security/SFHFKeychainUtils.h
+++ b/security/SFHFKeychainUtils.h
@@ -27,7 +27,7 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 
 @interface SFHFKeychainUtils : NSObject {


### PR DESCRIPTION
I exchanged `#import <UIKit/UIKit.h>` for `#import <Foundation/Foundation.h>`. With this little change you can just drop the two files into a OS X project and use them without any changes.
